### PR TITLE
Recorded mock

### DIFF
--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -87,9 +87,11 @@ liesl mock
    usage: liesl mock [-h] [--type TYPE]
    
    optional arguments:
-     -h, --help   show this help message and exit
-     --type TYPE  type of the stream
-     --file FILE  File that will be used as mock data
+     -h, --help       show this help message and exit
+     --type TYPE      type of the stream
+     --file FILE      file in xdf format that will be used as mock data
+     --stream STREAM  name of stream that will be used as mock data (only when file specified)
+
 
 
 liesl xdf

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -89,6 +89,7 @@ liesl mock
    optional arguments:
      -h, --help   show this help message and exit
      --type TYPE  type of the stream
+     --file FILE  File that will be used as mock data
 
 
 liesl xdf
@@ -103,8 +104,8 @@ liesl xdf
    optional arguments:
      -h, --help            show this help message and exit
      -a AT_MOST, --at-most AT_MOST
-                           return lastest once that many streams were found,
-                           regardloss of how long it takes. Useful if file is
+                           return latest once that many streams were found,
+                           regardless of how long it takes. Useful if file is
                            very large, and can prevent parsing the whole file.
                            defaults to sys.maxsize because integers are required,
                            but unbound in python. Set it to 0' to load the file
@@ -113,7 +114,7 @@ liesl xdf
                            return latest after this many seconds, regardless of
                            how many streams were found. Useful if the file is
                            very large, and you are sure you started recording all
-                           streams at the beginnging, as this prevents parsing
+                           streams at the beginning, as this prevents parsing
                            the whole file. defaults to 1 second. Set it to 'inf'
                            to load the file completely
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,7 +19,7 @@ from os import environ
 # -- Project information -----------------------------------------------------
 
 project = "LieSL"
-copyright = "2019, Robert Guggenberger"
+copyright = "2021, Robert Guggenberger"
 author = "Robert Guggenberger"
 
 # The full version, including alpha/beta/rc tags

--- a/liesl/cli/main.py
+++ b/liesl/cli/main.py
@@ -11,7 +11,6 @@ from ast import literal_eval
 
 
 def get_parser():
-
     parser = argparse.ArgumentParser(prog="liesl")
     subparsers = parser.add_subparsers(dest="subcommand")
 
@@ -73,6 +72,7 @@ def get_parser():
     helpstr = """mock a LSL stream"""
     parser_mock = subparsers.add_parser("mock", help=helpstr)
     parser_mock.add_argument("--type", help="type of the stream", default="EEG")
+    parser_mock.add_argument("--file", help="File that will be used as mock data")
 
     # xdf ---------------------------------------------------------------------
     helpstr = """inspect an XDF file"""
@@ -161,11 +161,55 @@ def show(args):
 
 
 def mock(args):
+    print(args)
     "execute subcommand mock"
     if "marker" in args.type.lower():
         from liesl.streams.mock import MarkerMock
 
         m = MarkerMock()
+    elif not (args.file is None):
+        """
+        Mocks a stream from a pre-recorded file
+        
+        Example: liesl mock --file=resting_EEG.xdf
+        Does only work for EEG data
+        """
+        from liesl.streams.mock import RecordedMock
+        from pyxdf import load_xdf
+        from pylsl import StreamInfo
+        streams, i = load_xdf(args.file)
+        print(f"Loaded file {args.file}")
+        streams_as_dict = {}
+        for ix, stream in enumerate(streams):
+            streamname_from_recorded = stream['info']['name'][0]
+            streams_as_dict[streamname_from_recorded] = stream
+        while True:
+            print("Select a stream")
+            stream_idx_pairs = {}
+            for idx, stream in enumerate(streams_as_dict):
+                stream_idx_pairs[idx] = stream
+                print(f"[{idx}] {stream}")
+            try:
+                index = int(input(f"Select a stream from 0-{len(stream_idx_pairs) - 1}: "))
+                if index > 0 and index < len(stream_idx_pairs):
+                    break
+                else:
+                    print("\Index is not in the correct range.")
+                    continue
+            except ValueError:
+                print("\nPlease input an integer")
+                continue
+        stream = streams_as_dict[stream_idx_pairs[index]]
+        info = stream["info"]
+        streaminfo = StreamInfo(
+            name="Recorded-Mock-EEG",
+            type=info["type"][0],
+            channel_count=int(info["channel_count"][0]),
+            nominal_srate=float(info["nominal_srate"][0]),
+            channel_format=info["channel_format"][0],
+            source_id=info["source_id"][0]
+        )
+        m = RecordedMock(stream, streaminfo)
     else:
         from liesl.streams.mock import Mock
 
@@ -245,4 +289,3 @@ liesl also offers a command line interface. This interface can be accessed after
         f.write(desc)
         for h in helpstr:
             f.write(h)
-

--- a/liesl/streams/mock.py
+++ b/liesl/streams/mock.py
@@ -14,16 +14,17 @@ from pylsl import StreamInfo, StreamOutlet, local_clock
 import threading
 from math import sin, pi
 
+
 # %%
 class Mock(threading.Thread):
     def __init__(
-        self,
-        name="Liesl-Mock-EEG",
-        type="EEG",
-        channel_count=8,
-        nominal_srate=1000,
-        channel_format="float32",
-        source_id=None,
+            self,
+            name="Liesl-Mock-EEG",
+            type="EEG",
+            channel_count=8,
+            nominal_srate=1000,
+            channel_format="float32",
+            source_id=None,
     ):
 
         threading.Thread.__init__(self)
@@ -83,11 +84,14 @@ class Mock(threading.Thread):
 
     def __str__(self):
         return self.info.as_xml()
+
+
 def _streams_to_string(streams_as_dict):
-    output =""
+    output = ""
     for idx, stream in enumerate(streams_as_dict):
         output += f"{stream}, "
     return output[:-2]
+
 
 def stream_from_file(file, streamname=None):
     from pyxdf import load_xdf
@@ -115,7 +119,7 @@ def stream_from_file(file, streamname=None):
             except ValueError:
                 print("\nPlease input an integer")
                 continue
-        streamname=stream_idx_pairs[index]
+        streamname = stream_idx_pairs[index]
 
     try:
         stream = streams_as_dict[streamname]
@@ -132,9 +136,10 @@ def stream_from_file(file, streamname=None):
     )
     return stream, streaminfo
 
+
 class RecordedMock(threading.Thread):
     def __init__(
-        self,
+            self,
             stream,
             info
     ):
@@ -171,13 +176,18 @@ class RecordedMock(threading.Thread):
         self.is_running = True
         timestamps = self.stream['time_stamps']
         timeseries = self.stream['time_series']
+        num_of_samples = len(timestamps)
 
         while self.is_running:
-            smpl = timeseries[count]
+            smpl = timeseries[count % num_of_samples]
             count += 1
             # now send it and wait for a bit
             outlet.push_sample(smpl)
-            time.sleep(timestamps[count+1]-timestamps[count])
+            time_diff = timestamps[(count + 1) % num_of_samples] - timestamps[count % num_of_samples]
+            if time_diff > 0:
+                time.sleep(time_diff)
+            else:
+                time.sleep(0.001)
 
     def __str__(self):
         return self.info.as_xml()
@@ -185,14 +195,14 @@ class RecordedMock(threading.Thread):
 
 class MarkerMock(Mock):
     def __init__(
-        self,
-        name="Liesl-Mock-Marker",
-        type="Marker",
-        channel_count=1,
-        nominal_srate=0,
-        channel_format="string",
-        source_id=None,
-        markernames=["Test", "Blah", "Marker", "XXX", "Testtest", "Test-1-2-3"],
+            self,
+            name="Liesl-Mock-Marker",
+            type="Marker",
+            channel_count=1,
+            nominal_srate=0,
+            channel_format="string",
+            source_id=None,
+            markernames=["Test", "Blah", "Marker", "XXX", "Testtest", "Test-1-2-3"],
     ):
 
         threading.Thread.__init__(self)
@@ -221,4 +231,3 @@ class MarkerMock(Mock):
             print(f"Pushed {sample} at {tstamp}")
             outlet.push_sample(sample, tstamp)
             time.sleep(rand())
-


### PR DESCRIPTION
This adds the option to use a pre-recorded xdf file to mock EEG data. It does not support marker streams.

It was tested with EEGO, BrainvisionRDA, and Spongebob data