### PR TITLE
Add gaze mock

### DIFF
--- a/liesl/cli/main.py
+++ b/liesl/cli/main.py
@@ -178,6 +178,10 @@ def mock(args):
         from liesl.streams.mock import MarkerMock
 
         m = MarkerMock()
+    elif "gaze" in args.type.lower():
+        from liesl.streams.mock import GazeMock
+
+        m = GazeMock()
     else:
         from liesl.streams.mock import Mock
 


### PR DESCRIPTION
This adds a gaze mock stream with a frequency of 60 Hz. The format is and the mock data is inspired from recorded data from https://pupil-labs-lsl-relay.readthedocs.io/en/stable/ , specifically a Neon device.
It can be used with 

```bash
liesl mock --type Gaze
```

This fixes #16 